### PR TITLE
Tools menu and assistant compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,8 @@ install_requires =
     napari-plugin-engine>=0.1.4
     numpy
     aydin
+    napari-tools-menu
+    napari-assistant
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ setup_requires = setuptools_scm
 install_requires =
     napari-plugin-engine>=0.1.4
     numpy
-    aydin
+    aydin==0.1.15rc0
     napari-tools-menu
     napari-assistant
 

--- a/src/napari_aydin/_function.py
+++ b/src/napari_aydin/_function.py
@@ -12,6 +12,7 @@ from enum import Enum
 import numpy as np
 from napari_plugin_engine import napari_hook_implementation
 
+from napari_tools_menu import register_function
 
 
 if TYPE_CHECKING:
@@ -27,11 +28,15 @@ def napari_experimental_provide_function():
     # or a list of multiple functions with or without options, as shown here:
     return [aydin_classic_denoise, aydin_noise2self_fgr]
 
+
+@register_function(menu="Filtering / noise removal > Classic denoise (aydin)")
 def aydin_classic_denoise(input_image: "napari.types.ImageData"
 ) -> "napari.types.ImageData":
     from aydin.restoration.denoise.classic import classic_denoise
     return classic_denoise(input_image)
 
+
+@register_function(menu="Filtering / noise removal > noise2self (fgr, aydin)")
 def aydin_noise2self_fgr(input_image: "napari.types.ImageData"
 ) -> "napari.types.ImageData":
     from aydin.restoration.denoise.noise2selffgr import noise2self_fgr

--- a/src/napari_aydin/_function.py
+++ b/src/napari_aydin/_function.py
@@ -27,17 +27,13 @@ def napari_experimental_provide_function():
     # we can return a single function
     # or a tuple of (function, magicgui_options)
     # or a list of multiple functions with or without options, as shown here:
-    return [aydin_denoise]  # [threshold, image_arithmetic]
+    return [aydin_classic_denoise, aydin_noise2self_fgr]
 
+def aydin_classic_denoise(input_image: "napari.types.ImageData"
+) -> "napari.types.ImageData":
+    return classic_denoise(input_image)
 
-# using Enums is a good way to get a dropdown menu.  Used here to select from np functions
-class Operation(Enum):
-    Noise2SelfFGR = noise2self_fgr
-    Butterworth = classic_denoise
+def aydin_noise2self_fgr(input_image: "napari.types.ImageData"
+) -> "napari.types.ImageData":
+    return noise2self_fgr(input_image)
 
-
-def aydin_denoise(
-    layerA: "napari.types.ImageData", operation: Operation, layerB: "napari.types.ImageData"
-) -> "napari.types.LayerDataTuple":
-    """Adds, subtracts, multiplies, or divides two same-shaped image layers."""
-    return (operation.value(layerA), {"colormap": "turbo"})

--- a/src/napari_aydin/_function.py
+++ b/src/napari_aydin/_function.py
@@ -29,14 +29,14 @@ def napari_experimental_provide_function():
     return [aydin_classic_denoise, aydin_noise2self_fgr]
 
 
-@register_function(menu="Filtering / noise removal > Classic denoise (aydin)")
+@register_function(menu="Filtering / noise removal > Classic denoise (classic-butterworth, aydin)")
 def aydin_classic_denoise(input_image: "napari.types.ImageData"
 ) -> "napari.types.ImageData":
     from aydin.restoration.denoise.classic import classic_denoise
-    return classic_denoise(input_image, variant='butterworth')
+    return classic_denoise(input_image)
 
 
-@register_function(menu="Filtering / noise removal > noise2self (fgr, aydin)")
+@register_function(menu="Filtering / noise removal > noise2self (fgr-catboost, aydin)")
 def aydin_noise2self_fgr(input_image: "napari.types.ImageData"
 ) -> "napari.types.ImageData":
     from aydin.restoration.denoise.noise2selffgr import noise2self_fgr

--- a/src/napari_aydin/_function.py
+++ b/src/napari_aydin/_function.py
@@ -12,8 +12,6 @@ from enum import Enum
 import numpy as np
 from napari_plugin_engine import napari_hook_implementation
 
-from aydin.restoration.denoise.classic import classic_denoise
-from aydin.restoration.denoise.noise2selffgr import noise2self_fgr
 
 
 if TYPE_CHECKING:
@@ -31,9 +29,11 @@ def napari_experimental_provide_function():
 
 def aydin_classic_denoise(input_image: "napari.types.ImageData"
 ) -> "napari.types.ImageData":
+    from aydin.restoration.denoise.classic import classic_denoise
     return classic_denoise(input_image)
 
 def aydin_noise2self_fgr(input_image: "napari.types.ImageData"
 ) -> "napari.types.ImageData":
+    from aydin.restoration.denoise.noise2selffgr import noise2self_fgr
     return noise2self_fgr(input_image)
 

--- a/src/napari_aydin/_function.py
+++ b/src/napari_aydin/_function.py
@@ -33,7 +33,7 @@ def napari_experimental_provide_function():
 def aydin_classic_denoise(input_image: "napari.types.ImageData"
 ) -> "napari.types.ImageData":
     from aydin.restoration.denoise.classic import classic_denoise
-    return classic_denoise(input_image)
+    return classic_denoise(input_image, variant='butterworth')
 
 
 @register_function(menu="Filtering / noise removal > noise2self (fgr, aydin)")


### PR DESCRIPTION
Hi @AhmetCanSolak ,

this is a PR-draft for making the denoising tools available in the [napari-tools-menu](https://github.com/haesleinhuepf/napari-tools-menu) and in the [napari-assistant](https://github.com/haesleinhuepf/napari-assistant) user interface:

![image](https://user-images.githubusercontent.com/12660498/175801746-f0f33a6c-97d8-414c-80f6-d66dc902f93c.png)

![image](https://user-images.githubusercontent.com/12660498/175801782-18115e4e-67f4-45e2-b8e0-109643f7e8ca.png)

Be careful with merging; it doesn't work yet. When I run [this function](https://github.com/haesleinhuepf/napari-aydin/blob/b1a795a5d3a93be7c91a8975993033146f25837b/src/napari_aydin/_function.py#L40) via the GUI, I receive this error:

```
File c:\structure\code\napari-aydin\src\napari_aydin\_function.py:43, in aydin_noise2self_fgr(input_image=<class 'numpy.ndarray'> (254, 256) uint8)
     39 @register_function(menu="Filtering / noise removal > noise2self (fgr, aydin)")
     40 def aydin_noise2self_fgr(input_image: "napari.types.ImageData"
     41 ) -> "napari.types.ImageData":
     42     from aydin.restoration.denoise.noise2selffgr import noise2self_fgr
---> 43     return noise2self_fgr(input_image)
        input_image = <class 'numpy.ndarray'> (254, 256) uint8

File ~\miniconda3\envs\aydin\lib\site-packages\aydin\restoration\denoise\noise2selffgr.py:329, in noise2self_fgr(noisy=<class 'numpy.ndarray'> (254, 256) uint8, batch_axes=None, chan_axes=None, variant=None)
    310 """Method to denoise an image with trained Noise2Self FGR.
    311
    312 Parameters
   (...)
    326
    327 """
    328 # Run N2S and save the result
--> 329 n2s = Noise2SelfFGR(variant=variant)
        Noise2SelfFGR = <class 'aydin.restoration.denoise.noise2selffgr.Noise2SelfFGR'>
        variant = None
    331 # Train
    332 n2s.train(noisy, batch_axes=batch_axes, chan_axes=chan_axes)

TypeError: __init__() got an unexpected keyword argument 'variant'
Callback for minimizer starting at [0.984375 0.328125]:
Callback for minimizer starting at [0.453125 0.359375]:
Callback for minimizer starting at [0.6015625 0.3203125]:
2022-06-25 23:25:14.813 | ERROR    | napari_assistant._gui._category_widget:gui_function:415 - An error has been caught in function 'gui_function', process 'MainProcess' (16968), thread 'MainThread' (13284):
Traceback (most recent call last):

  File "C:\Users\rober\miniconda3\envs\aydin\Scripts\napari-script.py", line 9, in <module>
    sys.exit(main())
    │   │    └ <function main at 0x000001D8C36A9430>
    │   └ <built-in function exit>
    └ <module 'sys' (built-in)>

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\napari\__main__.py", line 447, in main
    _run()
    └ <function _run at 0x000001D8C36A9280>

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\napari\__main__.py", line 336, in _run
    run(gui_exceptions=True)
    └ <function run at 0x000001D8BB47B670>

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\napari\_qt\qt_event_loop.py", line 402, in run
    app.exec_()
    │   └ <built-in method exec_>
    └ <PyQt5.QtWidgets.QApplication object at 0x000001D8C3E65AF0>

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\magicgui\backends\_qtpy\widgets.py", line 726, in _emit_data
    self._event_filter.valueChanged.emit(self._qwidget.itemData(index))
    │    │             │                 │    │        │        └ 1
    │    │             │                 │    │        └ <built-in method itemData>
    │    │             │                 │    └ <PyQt5.QtWidgets.QComboBox object at 0x000001D906F4B3A0>
    │    │             │                 └ <magicgui.backends._qtpy.widgets.ComboBox object at 0x000001D90305A040>
    │    │             └ <unbound PYQT_SIGNAL valueChanged(PyQt_PyObject)>
    │    └ <magicgui.backends._qtpy.widgets.EventFilter object at 0x000001D906F4B550>
    └ <magicgui.backends._qtpy.widgets.ComboBox object at 0x000001D90305A040>

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\magicgui\widgets\_bases\value_widget.py", line 57, in _on_value_change
    self.changed.emit(value)
    │    │       │    └ 'noise2self (fgr, aydin)'
    │    │       └ <cyfunction SignalInstance.emit at 0x000001D8E9E48C70>
    │    └ <SignalInstance 'changed' on ComboBox(value='noise2self (fgr, aydin)', annotation=<class 'str'>, name='op_name')>
    └ ComboBox(value='noise2self (fgr, aydin)', annotation=<class 'str'>, name='op_name')

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\magicgui\widgets\_bases\container_widget.py", line 170, in <lambda>
    widget.changed.connect(lambda: self.changed.emit(self))
                                   │    │       │    └ <FunctionGui do_remove_noise(*, input0: napari.layers.image.image.Image = <Image layer 'Result of aydin_classic_denoise' at 0...
                                   │    │       └ <cyfunction SignalInstance.emit at 0x000001D8E9E48C70>
                                   │    └ <SignalInstance 'changed' on <FunctionGui do_remove_noise(*, input0: napari.layers.image.image.Image = <Image layer 'Result o...
                                   └ <FunctionGui do_remove_noise(*, input0: napari.layers.image.image.Image = <Image layer 'Result of aydin_classic_denoise' at 0...

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\magicgui\widgets\_function_gui.py", line 235, in _on_change
    self()
    └ <FunctionGui do_remove_noise(*, input0: napari.layers.image.image.Image = <Image layer 'Result of aydin_classic_denoise' at 0...

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\magicgui\widgets\_function_gui.py", line 318, in __call__
    value = self._function(*bound.args, **bound.kwargs)
            │    │          │     │       │     └ <property object at 0x000001D8E9D1F950>
            │    │          │     │       └ <BoundArguments (input0=<Image layer 'Result of aydin_classic_denoise' at 0x1d8d89786d0>, op_name='noise2self (fgr, aydin)', ...
            │    │          │     └ <property object at 0x000001D8E9D1F900>
            │    │          └ <BoundArguments (input0=<Image layer 'Result of aydin_classic_denoise' at 0x1d8d89786d0>, op_name='noise2self (fgr, aydin)', ...
            │    └ <function make_gui_for_category.<locals>.gui_function at 0x000001D906F4B0D0>
            └ <FunctionGui do_remove_noise(*, input0: napari.layers.image.image.Image = <Image layer 'Result of aydin_classic_denoise' at 0...

> File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\napari_assistant\_gui\_category_widget.py", line 415, in gui_function
    result, used_args = call_op(op_name, inputs, t_position, viewer, **kwargs)
                        │       │        │       │           │         └ {'x': 1.0, 'y': 1.0, 'z': 0.0, 'u': 0.0, 'v': 0.0, 'w': 0.0, 'a': False, 'b': False, 'c': False, 'd': False, 'e': False, 'f':...
                        │       │        │       │           └ Viewer(axes=Axes(visible=False, labels=True, colored=True, dashed=False, arrows=True), camera=Camera(center=(0.0, 126.5, 127....
                        │       │        │       └ None
                        │       │        └ [<Image layer 'Result of aydin_classic_denoise' at 0x1d8d89786d0>]
                        │       └ 'noise2self (fgr, aydin)'
                        └ <function call_op at 0x000001D8CD525310>

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\napari_assistant\_gui\_category_widget.py", line 194, in call_op
    gpu_out = cle_function(*args, **kwargs)
              │             │       └ {}
              │             └ [array([[ 52,  38,  23, ..., 220, 204, 204],
              │                      [ 55,  40,  23, ..., 228, 214, 214],
              │                      [ 52,  41,  26, ..., 239, 227...
              └ <function aydin_noise2self_fgr at 0x000001D8C3B761F0>

  File "c:\structure\code\napari-aydin\src\napari_aydin\_function.py", line 43, in aydin_noise2self_fgr
    return noise2self_fgr(input_image)
           │              └ array([[ 52,  38,  23, ..., 220, 204, 204],
           │                       [ 55,  40,  23, ..., 228, 214, 214],
           │                       [ 52,  41,  26, ..., 239, 227,...
           └ <function noise2self_fgr at 0x000001D8CE166940>

  File "C:\Users\rober\miniconda3\envs\aydin\lib\site-packages\aydin\restoration\denoise\noise2selffgr.py", line 329, in noise2self_fgr
    n2s = Noise2SelfFGR(variant=variant)
          │                     └ None
          └ <class 'aydin.restoration.denoise.noise2selffgr.Noise2SelfFGR'>

TypeError: __init__() got an unexpected keyword argument 'variant'
```



